### PR TITLE
Firefox & Cache Improvements

### DIFF
--- a/src/script/authorize.html
+++ b/src/script/authorize.html
@@ -3,11 +3,14 @@
 <head>
     <meta charset="UTF-8">
     <title>Authorize Character</title>
+    <script type="application/javascript">
+        function closeAuthModal() {
+            setTimeout( function() { google.script.host.close(); }, 500);
+        }
+    </script>
 </head>
 <body>
     <p>Click the link below to authorize a character for use in GESI:</p>
-    <a href="<?= authorizationUrl ?>" target="_blank"><img onclick="google.script.host.close();" alt="Authorize with EVE SSO" src="https://web.ccpgamescdn.com/eveonlineassets/developers/eve-sso-login-black-small.png"/></a>
-    <br>
-    <p>NOTE: If using Firefox, right click on the link and open it in a new tab.</p>
+    <a href="<?= authorizationUrl ?>" target="_blank" onclick="closeAuthModal()"><img alt="Authorize with EVE SSO" src="https://web.ccpgamescdn.com/eveonlineassets/developers/eve-sso-login-black-small.png"/></a>
 </body>
 </html>

--- a/src/script/gesi.ts
+++ b/src/script/gesi.ts
@@ -241,13 +241,6 @@ function getClient(characterName?: string): ESIClient {
 }
 
 /**
- * @internal
- */
-function getClientInternal(id: string, refreshToken: string, characterData: IAuthenticatedCharacter): ESIClient {
-  return new ESIClient(getOAuthService_(id, refreshToken), characterData);
-}
-
-/**
  * Returns the data from the provided functionName for each character as one list for use within a sheet.
  *
  * @param {string} functionName The name of the endpoint that should be invoked
@@ -377,7 +370,8 @@ function getOAuthService_(id: string, refreshToken?: string): OAuth2Service {
   } else {
     service
       .setPropertyStore(getDocumentProperties_())
-      .setCache(getDocumentCache_());
+      .setCache(getDocumentCache_())
+      .setExpirationMinutes('18');
   }
 
   return service;


### PR DESCRIPTION
Fixes #76.

* Adds a small timeout before closing the OAuth modal in order to give Firefox time to actually open the link
* Sets the proper token lifespan on the OAuth client
* Remove unused function